### PR TITLE
docs: Add API interaction details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,97 @@ Result:
 
 [▶️ Download the example podcast](./example/audio/karpathy_os.wav)
 
+## Accessing the Agent via API
+
+When the agent is served (e.g., using `langgraph dev`), it can be accessed via HTTP API endpoints. This is useful for programmatic interaction, such as from a separate frontend application (e.g., a React app).
+
+The primary endpoint for running the research graph is:
+
+-   **Endpoint:** `/invoke` (or `/graph_id/invoke` if a specific graph ID is targeted, e.g., `/research_agent/invoke`. The exact path might depend on your `langgraph.json` and server setup. Check the API server's startup logs or `/docs` for the precise URL, often `http://127.0.0.1:2024/invoke` for the default graph when using `langgraph dev`).
+-   **Method:** `POST`
+-   **Request Body:** A JSON object. The main input should be provided under an `"input"` key, matching the `ResearchStateInput` schema.
+    ```json
+    {
+      "input": {
+        "topic": "Topic to research",
+        "research_approach": "Topic Only", // or "Topic Company Leads"
+        "company_name": null, // or "Company Name" if approach is "Topic Company Leads"
+        "title_areas": null, // or ["Title1", "Title2"] if approach is "Topic Company Leads"
+        "video_url": null, // or "https://youtube_url.com"
+        "create_podcast": false // or true
+      }
+      // Optionally, a "config" key can be added here for runtime configurations
+      // "config": {"configurable": {"some_config_key": "value"}}
+    }
+    ```
+    **Example Request (Topic Company Leads):**
+    ```json
+    {
+      "input": {
+        "topic": "AI in Enterprise Search",
+        "research_approach": "Topic Company Leads",
+        "company_name": "Coveo",
+        "title_areas": ["VP of Engineering", "AI Research Lead"],
+        "video_url": null,
+        "create_podcast": true
+      }
+    }
+    ```
+
+-   **Response Body:** A JSON object, typically with an `"output"` key containing the results matching the `ResearchStateOutput` schema.
+    ```json
+    {
+      "output": {
+        "report": "Comprehensive markdown report text...",
+        "identified_leads": [
+          {
+            "lead_name": "Jane Doe",
+            "lead_title": "VP of Engineering",
+            "lead_department": "Engineering",
+            "linkedin_url": "https://linkedin.com/in/janedoe",
+            "summary_of_relevance": "...",
+            "named_buyers": [
+              {"buyer_name": "John Smith", "buyer_title": "CTO", "buyer_rationale": "..."}
+            ]
+          }
+        ],
+        "linkedin_cse_contacts": [
+          {"title": "Jane Doe - VP of Engineering at Coveo | LinkedIn", "link": "https://linkedin.com/in/janedoe", "snippet": "..."}
+        ],
+        "podcast_script": "Mike: Welcome to the show...\\nDr. Sarah: ...",
+        "podcast_url": "https://storage.googleapis.com/your-bucket/podcasts/podcast_file.wav"
+      }
+      // Note: Some fields will be null if not generated (e.g., podcast fields if create_podcast was false,
+      // or lead fields if research_approach was "Topic Only").
+    }
+    ```
+
+-   **Example cURL Command:**
+    ```bash
+    curl -X POST http://127.0.0.1:2024/invoke \
+    -H "Content-Type: application/json" \
+    -d '{
+      "input": {
+        "topic": "AI in Enterprise Search",
+        "research_approach": "Topic Company Leads",
+        "company_name": "Coveo",
+        "title_areas": ["VP of Engineering", "AI Research Lead"],
+        "video_url": null,
+        "create_podcast": false
+      }
+    }'
+    ```
+
+### Other Endpoints
+
+-   **Streaming:** A `/stream` endpoint (e.g., `http://127.0.0.1:2024/stream`) may also be available for receiving intermediate outputs from the graph as Server-Sent Events (SSE). This is more complex to integrate but can provide a more responsive UI for long-running tasks.
+-   **API Docs:** The LangGraph server typically provides OpenAPI (Swagger) documentation at its `/docs` path (e.g., `http://127.0.0.1:2024/docs`), where you can explore all available endpoints and schemas.
+
+### CORS (Cross-Origin Resource Sharing)
+
+If your React frontend is served from a different domain or port than the LangGraph API (e.g., React app on `http://localhost:3000` and API on `http://localhost:2024`), you will need to enable CORS on the LangGraph API server.
+When using `langgraph dev`, you can often pass flags like `--cors-origins \"http://localhost:3000\"` (or your React app's URL). For production deployments, CORS policies would be configured at the API gateway or server level.
+
 ## Architecture
 
 The system implements a LangGraph workflow with the following nodes:


### PR DESCRIPTION
Adds a new section "Accessing the Agent via API" to README.md. This section documents:
- The typical API endpoint for graph invocation (e.g., /invoke).
- HTTP method (POST).
- Expected JSON request body structure with examples for different research approaches.
- Expected JSON response body structure with an example.
- An example cURL command.
- Brief mentions of streaming endpoints and API docs.
- A note on CORS configuration for frontend integration.